### PR TITLE
UTF-8 accented characters proper sending

### DIFF
--- a/FormTemplateProcessor.module
+++ b/FormTemplateProcessor.module
@@ -161,7 +161,7 @@ class FormTemplateProcessor extends WireData implements Module {
 			if(in_array($field->name, $this->skipFields)) continue; 
 
 			$label = $field->label;
-			$value = htmlentities($this->contact->get($field->name));
+			$value = htmlentities($this->contact->get($field->name), ENT_COMPAT, "UTF-8");
 
 			$message .= "<h2>$label</h2><p>$value</p>";
 
@@ -172,7 +172,7 @@ class FormTemplateProcessor extends WireData implements Module {
 		}
 
 		$message = "<html><head></head><body>$message</body></html>";
-		$headers = "Content-Type: text/html;";
+		$headers = "Content-type: text/html; charset=UTF-8" . "\r\n";
 
 		if($fromEmail) $headers = "From: $fromEmail\n$headers";
 


### PR DESCRIPTION
I just fixed the sending of UTF-8-encoded accented characters.

I tried to send some Slovak characters for testing:

ľščťžýáíé

Before the fix it sent:
Ä¾Å¡Ä�Å¥Å¾Ã½Ã¡Ã­Ã©
...encoded as
<p>&Auml;&frac34;&Aring;&iexcl;&Auml;_&Aring;&yen;&Aring;&frac34;&Atilde;&frac12;&Atilde;&iexcl;&Atilde;&shy;&Atilde;&copy;</p>

After the fix it sent:
ľščťžýáíé
...encoded as
    <p>ľ&scaron;čťž&yacute;&aacute;&iacute;&eacute;</p> 
... which is not perfect, but much better than before the fix.
